### PR TITLE
Removed prototype

### DIFF
--- a/CustomHTMLScroll.js
+++ b/CustomHTMLScroll.js
@@ -19,10 +19,11 @@
  * davidmaes@outlook.com
  */
 
-Element.prototype.addCustomHTMLScroll = function()
-{	var customScroll = CustomHTMLScroll( this );	
+var addCustomHTMLScroll = function( element )
+{
+	var customScroll = CustomHTMLScroll( element );	
 	customScroll.setup();
-}
+};
 
 function CustomHTMLScroll( content )
 {


### PR DESCRIPTION
I removed binding to the prototype object as it is not good binding to a prototype that might change and is not a custom object.

This will also necessitate a change in instantiation:
```
var myElement = document.querySelector('#my-scroll-element');
addCustomHTMLScroll( myElement );
```

Instead of using:
```
var myElement = document.querySelector('#my-scroll-element');
myElement.addCustomHTMLScroll();
```